### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -40,5 +40,5 @@ appropriate to the circumstances. Maintainers are obligated to maintain confiden
 with regard to the reporter of an incident.
 
 This Code of Conduct is adapted from the
-http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
-http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]
+https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
+https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]

--- a/spring-cloud-deployer-admin-configuration-metadata/src/main/java/org/springframework/cloud/deployer/admin/configuration/metadata/ApplicationConfigurationMetadataResolver.java
+++ b/spring-cloud-deployer-admin-configuration-metadata/src/main/java/org/springframework/cloud/deployer/admin/configuration/metadata/ApplicationConfigurationMetadataResolver.java
@@ -52,7 +52,7 @@ public abstract class ApplicationConfigurationMetadataResolver {
 
 	/**
 	 * Return metadata about configuration properties that are documented via
-	 * <a href="http://docs.spring.io/spring-boot/docs/current/reference/html/configuration-metadata.html">
+	 * <a href="https://docs.spring.io/spring-boot/docs/current/reference/html/configuration-metadata.html">
 	 * Spring Boot configuration metadata</a> and visible in an app.
 	 * @param app a Spring Cloud Stream app; typically a Boot uberjar,
 	 *            but directories are supported as well

--- a/spring-cloud-deployer-admin-configuration-metadata/src/main/java/org/springframework/cloud/deployer/admin/configuration/metadata/BootApplicationConfigurationMetadataResolver.java
+++ b/spring-cloud-deployer-admin-configuration-metadata/src/main/java/org/springframework/cloud/deployer/admin/configuration/metadata/BootApplicationConfigurationMetadataResolver.java
@@ -91,7 +91,7 @@ public class BootApplicationConfigurationMetadataResolver extends ApplicationCon
 
 	/**
 	 * Return metadata about configuration properties that are documented via
-	 * <a href="http://docs.spring.io/spring-boot/docs/current/reference/html/configuration-metadata.html">
+	 * <a href="https://docs.spring.io/spring-boot/docs/current/reference/html/configuration-metadata.html">
 	 * Spring Boot configuration metadata</a> and visible in an app.
 	 * @param app a Spring Cloud Stream app; typically a Boot uberjar,
 	 *            but directories are supported as well

--- a/spring-cloud-deployer-admin-rest-client/src/main/java/org/springframework/cloud/deployer/admin/rest/client/DataFlowTemplate.java
+++ b/spring-cloud-deployer-admin-rest-client/src/main/java/org/springframework/cloud/deployer/admin/rest/client/DataFlowTemplate.java
@@ -86,7 +86,7 @@ public class DataFlowTemplate implements DataFlowOperations {
 	 * </ul><p>
 	 *
 	 * For more information see
-	 * <a href="http://docs.oracle.com/javase/7/docs/technotes/guides/net/properties.html">this link</a>
+	 * <a href="https://docs.oracle.com/javase/7/docs/technotes/guides/net/properties.html">this link</a>
 	 *
 	 * @param baseURI Must not be null
 	 */

--- a/spring-cloud-deployer-admin-rest-client/src/test/java/org/springframework/cloud/deployer/admin/rest/client/DataflowTemplateTests.java
+++ b/spring-cloud-deployer-admin-rest-client/src/test/java/org/springframework/cloud/deployer/admin/rest/client/DataflowTemplateTests.java
@@ -64,7 +64,7 @@ public class DataflowTemplateTests {
 
 	@Test(expected = ResourceAccessException.class)
 	public void testDataFlowTemplateContructorWithNonExistingUri() throws URISyntaxException {
-			new DataFlowTemplate(new URI("http://doesnotexist:1234"));
+			new DataFlowTemplate(new URI("https://doesnotexist:1234"));
 	}
 
 	@Test

--- a/spring-cloud-deployer-admin-server-core/src/test/resources/app-registry-bad.properties
+++ b/spring-cloud-deployer-admin-server-core/src/test/resources/app-registry-bad.properties
@@ -1,4 +1,4 @@
 <html>
 <head><title>Bitly</title></head>
-<body><a href="http://repo.spring.io/libs-release-local/org/springframework/cloud/stream/app/spring-cloud-stream-app-descriptor/Avogadro.RELEASE/spring-cloud-stream-app-descriptor-Avogadro.RELEASE.stream-apps-rabbit-maven">moved here</a></body>
+<body><a href="https://repo.spring.io/libs-release-local/org/springframework/cloud/stream/app/spring-cloud-stream-app-descriptor/Avogadro.RELEASE/spring-cloud-stream-app-descriptor-Avogadro.RELEASE.stream-apps-rabbit-maven">moved here</a></body>
 </html>

--- a/spring-cloud-deployer-admin-server-local/README.adoc
+++ b/spring-cloud-deployer-admin-server-local/README.adoc
@@ -93,13 +93,13 @@ If you tail the `stdout_0.log` file from the directory mentioned, you should see
 ## Configuration
 
 ### Default
-To configure the Data Flow Server you can follow the configuration setup guidelines specified in the boot documentation found http://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html[here]
+To configure the Data Flow Server you can follow the configuration setup guidelines specified in the boot documentation found https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html[here]
 
 Note: The `dataflow-server.yml` containing the defaults can be found https://github.com/spring-cloud/spring-cloud-dataflow/blob/master/spring-cloud-starter-dataflow-server-local/src/main/resources/dataflow-server.yml[here]
 
 ### Spring Cloud Configuration
 The Spring Cloud Data Flow Server offers the user the ability to configure properties via
-http://cloud.spring.io/spring-cloud-config/spring-cloud-config.html[spring-cloud-config].
+https://cloud.spring.io/spring-cloud-config/spring-cloud-config.html[spring-cloud-config].
 All configurations retrieved from the cloud config will take precedence over Boot's
 defaults enumerated above. The Spring Cloud Data Flow Server will look for the server at
 `localhost:8888`, however this can be overwritten by setting the `spring.cloud.config.uri`


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://doesnotexist:1234 (UnknownHostException) with 1 occurrences migrated to:  
  https://doesnotexist:1234 ([https](https://doesnotexist:1234) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://cloud.spring.io/spring-cloud-config/spring-cloud-config.html with 1 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-config/spring-cloud-config.html ([https](https://cloud.spring.io/spring-cloud-config/spring-cloud-config.html) result 200).
* [ ] http://docs.oracle.com/javase/7/docs/technotes/guides/net/properties.html with 1 occurrences migrated to:  
  https://docs.oracle.com/javase/7/docs/technotes/guides/net/properties.html ([https](https://docs.oracle.com/javase/7/docs/technotes/guides/net/properties.html) result 200).
* [ ] http://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html ([https](https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html) result 200).
* [ ] http://docs.spring.io/spring-boot/docs/current/reference/html/configuration-metadata.html with 2 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/current/reference/html/configuration-metadata.html ([https](https://docs.spring.io/spring-boot/docs/current/reference/html/configuration-metadata.html) result 200).
* [ ] http://repo.spring.io/libs-release-local/org/springframework/cloud/stream/app/spring-cloud-stream-app-descriptor/Avogadro.RELEASE/spring-cloud-stream-app-descriptor-Avogadro.RELEASE.stream-apps-rabbit-maven with 1 occurrences migrated to:  
  https://repo.spring.io/libs-release-local/org/springframework/cloud/stream/app/spring-cloud-stream-app-descriptor/Avogadro.RELEASE/spring-cloud-stream-app-descriptor-Avogadro.RELEASE.stream-apps-rabbit-maven ([https](https://repo.spring.io/libs-release-local/org/springframework/cloud/stream/app/spring-cloud-stream-app-descriptor/Avogadro.RELEASE/spring-cloud-stream-app-descriptor-Avogadro.RELEASE.stream-apps-rabbit-maven) result 200).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).

# Ignored
These URLs were intentionally ignored.

* http://127.0.0.1:9999/me with 1 occurrences
* http://127.0.0.1:9999/oauth/authorize with 1 occurrences
* http://127.0.0.1:9999/oauth/token with 1 occurrences
* http://localhost:%s with 1 occurrences
* http://localhost:8761/eureka/ with 1 occurrences
* http://localhost:8888 with 1 occurrences
* http://localhost:8888/spring-cloud-dataflow-server/default with 1 occurrences
* http://localhost:9393 with 6 occurrences
* http://localhost:9393/streams/definitions with 1 occurrences
* http://localhost:9393/streams/definitions?deploy=false with 1 occurrences
* http://localhost:9393/streams/deployments/ticktock with 1 occurrences
* http://test1URI with 4 occurrences
* http://test2URI with 4 occurrences