### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-completion/src/main/java/org/springframework/cloud/deployer/admin/completion/BooleanValueHintProvider.java
+++ b/spring-cloud-deployer-admin-completion/src/main/java/org/springframework/cloud/deployer/admin/completion/BooleanValueHintProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-completion/src/main/java/org/springframework/cloud/deployer/admin/completion/CompletionConfiguration.java
+++ b/spring-cloud-deployer-admin-completion/src/main/java/org/springframework/cloud/deployer/admin/completion/CompletionConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-completion/src/main/java/org/springframework/cloud/deployer/admin/completion/CompletionProposal.java
+++ b/spring-cloud-deployer-admin-completion/src/main/java/org/springframework/cloud/deployer/admin/completion/CompletionProposal.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-completion/src/main/java/org/springframework/cloud/deployer/admin/completion/CompletionUtils.java
+++ b/spring-cloud-deployer-admin-completion/src/main/java/org/springframework/cloud/deployer/admin/completion/CompletionUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-completion/src/main/java/org/springframework/cloud/deployer/admin/completion/DefaultValueHintProvider.java
+++ b/spring-cloud-deployer-admin-completion/src/main/java/org/springframework/cloud/deployer/admin/completion/DefaultValueHintProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-completion/src/main/java/org/springframework/cloud/deployer/admin/completion/EnumValueHintProvider.java
+++ b/spring-cloud-deployer-admin-completion/src/main/java/org/springframework/cloud/deployer/admin/completion/EnumValueHintProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-completion/src/main/java/org/springframework/cloud/deployer/admin/completion/RecoveryStrategy.java
+++ b/spring-cloud-deployer-admin-completion/src/main/java/org/springframework/cloud/deployer/admin/completion/RecoveryStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-completion/src/main/java/org/springframework/cloud/deployer/admin/completion/ValueHintProvider.java
+++ b/spring-cloud-deployer-admin-completion/src/main/java/org/springframework/cloud/deployer/admin/completion/ValueHintProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-completion/src/test/java/org/springframework/cloud/deployer/admin/completion/Expresso.java
+++ b/spring-cloud-deployer-admin-completion/src/test/java/org/springframework/cloud/deployer/admin/completion/Expresso.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-completion/src/test/java/org/springframework/cloud/deployer/admin/completion/Proposals.java
+++ b/spring-cloud-deployer-admin-completion/src/test/java/org/springframework/cloud/deployer/admin/completion/Proposals.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-completion/src/test/support/boot13/src/main/java/com/acme/boot13/AnotherEnumClass13.java
+++ b/spring-cloud-deployer-admin-completion/src/test/support/boot13/src/main/java/com/acme/boot13/AnotherEnumClass13.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-completion/src/test/support/boot13/src/main/java/com/acme/boot13/Main.java
+++ b/spring-cloud-deployer-admin-completion/src/test/support/boot13/src/main/java/com/acme/boot13/Main.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-completion/src/test/support/boot13/src/main/java/com/acme/boot13/MyConfigProperties13.java
+++ b/spring-cloud-deployer-admin-completion/src/test/support/boot13/src/main/java/com/acme/boot13/MyConfigProperties13.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-completion/src/test/support/boot14/src/main/java/com/acme/boot14/AnotherEnumClass14.java
+++ b/spring-cloud-deployer-admin-completion/src/test/support/boot14/src/main/java/com/acme/boot14/AnotherEnumClass14.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-completion/src/test/support/boot14/src/main/java/com/acme/boot14/Main.java
+++ b/spring-cloud-deployer-admin-completion/src/test/support/boot14/src/main/java/com/acme/boot14/Main.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-completion/src/test/support/boot14/src/main/java/com/acme/boot14/MyConfigProperties14.java
+++ b/spring-cloud-deployer-admin-completion/src/test/support/boot14/src/main/java/com/acme/boot14/MyConfigProperties14.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-completion/src/test/support/common/src/main/java/com/acme/common/ConfigProperties.java
+++ b/spring-cloud-deployer-admin-completion/src/test/support/common/src/main/java/com/acme/common/ConfigProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-completion/src/test/support/common/src/main/java/com/acme/common/SomeEnum.java
+++ b/spring-cloud-deployer-admin-completion/src/test/support/common/src/main/java/com/acme/common/SomeEnum.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-configuration-metadata/src/main/java/org/springframework/cloud/deployer/admin/configuration/metadata/ApplicationConfigurationMetadataResolver.java
+++ b/spring-cloud-deployer-admin-configuration-metadata/src/main/java/org/springframework/cloud/deployer/admin/configuration/metadata/ApplicationConfigurationMetadataResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-configuration-metadata/src/main/java/org/springframework/cloud/deployer/admin/configuration/metadata/ApplicationConfigurationMetadataResolverAutoConfiguration.java
+++ b/spring-cloud-deployer-admin-configuration-metadata/src/main/java/org/springframework/cloud/deployer/admin/configuration/metadata/ApplicationConfigurationMetadataResolverAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-configuration-metadata/src/main/java/org/springframework/cloud/deployer/admin/configuration/metadata/BootApplicationConfigurationMetadataResolver.java
+++ b/spring-cloud-deployer-admin-configuration-metadata/src/main/java/org/springframework/cloud/deployer/admin/configuration/metadata/BootApplicationConfigurationMetadataResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-configuration-metadata/src/main/java/org/springframework/cloud/deployer/admin/configuration/metadata/BootClassLoaderFactory.java
+++ b/spring-cloud-deployer-admin-configuration-metadata/src/main/java/org/springframework/cloud/deployer/admin/configuration/metadata/BootClassLoaderFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-configuration-metadata/src/main/java/org/springframework/cloud/deployer/admin/configuration/metadata/DelegatingApplicationConfigurationMetadataResolver.java
+++ b/spring-cloud-deployer-admin-configuration-metadata/src/main/java/org/springframework/cloud/deployer/admin/configuration/metadata/DelegatingApplicationConfigurationMetadataResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-configuration-metadata/src/test/java/org/springframework/cloud/deployer/admin/configuration/metadata/BootApplicationConfigurationMetadataResolverTests.java
+++ b/spring-cloud-deployer-admin-configuration-metadata/src/test/java/org/springframework/cloud/deployer/admin/configuration/metadata/BootApplicationConfigurationMetadataResolverTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-core/src/main/java/org/springframework/cloud/deployer/admin/core/ApplicationDefinition.java
+++ b/spring-cloud-deployer-admin-core/src/main/java/org/springframework/cloud/deployer/admin/core/ApplicationDefinition.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-core/src/main/java/org/springframework/cloud/deployer/admin/core/DataFlowAppDefinition.java
+++ b/spring-cloud-deployer-admin-core/src/main/java/org/springframework/cloud/deployer/admin/core/DataFlowAppDefinition.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-core/src/main/java/org/springframework/cloud/deployer/admin/core/dsl/AppNode.java
+++ b/spring-cloud-deployer-admin-core/src/main/java/org/springframework/cloud/deployer/admin/core/dsl/AppNode.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-core/src/main/java/org/springframework/cloud/deployer/admin/core/dsl/AppParser.java
+++ b/spring-cloud-deployer-admin-core/src/main/java/org/springframework/cloud/deployer/admin/core/dsl/AppParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-core/src/main/java/org/springframework/cloud/deployer/admin/core/dsl/ApplicationParser.java
+++ b/spring-cloud-deployer-admin-core/src/main/java/org/springframework/cloud/deployer/admin/core/dsl/ApplicationParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-core/src/main/java/org/springframework/cloud/deployer/admin/core/dsl/ArgumentNode.java
+++ b/spring-cloud-deployer-admin-core/src/main/java/org/springframework/cloud/deployer/admin/core/dsl/ArgumentNode.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-core/src/main/java/org/springframework/cloud/deployer/admin/core/dsl/AstNode.java
+++ b/spring-cloud-deployer-admin-core/src/main/java/org/springframework/cloud/deployer/admin/core/dsl/AstNode.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-core/src/main/java/org/springframework/cloud/deployer/admin/core/dsl/CheckPointedParseException.java
+++ b/spring-cloud-deployer-admin-core/src/main/java/org/springframework/cloud/deployer/admin/core/dsl/CheckPointedParseException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-core/src/main/java/org/springframework/cloud/deployer/admin/core/dsl/DSLMessage.java
+++ b/spring-cloud-deployer-admin-core/src/main/java/org/springframework/cloud/deployer/admin/core/dsl/DSLMessage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-core/src/main/java/org/springframework/cloud/deployer/admin/core/dsl/DestinationNode.java
+++ b/spring-cloud-deployer-admin-core/src/main/java/org/springframework/cloud/deployer/admin/core/dsl/DestinationNode.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-core/src/main/java/org/springframework/cloud/deployer/admin/core/dsl/LabelNode.java
+++ b/spring-cloud-deployer-admin-core/src/main/java/org/springframework/cloud/deployer/admin/core/dsl/LabelNode.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-core/src/main/java/org/springframework/cloud/deployer/admin/core/dsl/ParseException.java
+++ b/spring-cloud-deployer-admin-core/src/main/java/org/springframework/cloud/deployer/admin/core/dsl/ParseException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-core/src/main/java/org/springframework/cloud/deployer/admin/core/dsl/SinkDestinationNode.java
+++ b/spring-cloud-deployer-admin-core/src/main/java/org/springframework/cloud/deployer/admin/core/dsl/SinkDestinationNode.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-core/src/main/java/org/springframework/cloud/deployer/admin/core/dsl/SourceDestinationNode.java
+++ b/spring-cloud-deployer-admin-core/src/main/java/org/springframework/cloud/deployer/admin/core/dsl/SourceDestinationNode.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-core/src/main/java/org/springframework/cloud/deployer/admin/core/dsl/StreamNode.java
+++ b/spring-cloud-deployer-admin-core/src/main/java/org/springframework/cloud/deployer/admin/core/dsl/StreamNode.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-core/src/main/java/org/springframework/cloud/deployer/admin/core/dsl/StreamParser.java
+++ b/spring-cloud-deployer-admin-core/src/main/java/org/springframework/cloud/deployer/admin/core/dsl/StreamParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-core/src/main/java/org/springframework/cloud/deployer/admin/core/dsl/Token.java
+++ b/spring-cloud-deployer-admin-core/src/main/java/org/springframework/cloud/deployer/admin/core/dsl/Token.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-core/src/main/java/org/springframework/cloud/deployer/admin/core/dsl/TokenKind.java
+++ b/spring-cloud-deployer-admin-core/src/main/java/org/springframework/cloud/deployer/admin/core/dsl/TokenKind.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-core/src/main/java/org/springframework/cloud/deployer/admin/core/dsl/Tokenizer.java
+++ b/spring-cloud-deployer-admin-core/src/main/java/org/springframework/cloud/deployer/admin/core/dsl/Tokenizer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-core/src/main/java/org/springframework/cloud/deployer/admin/core/dsl/Tokens.java
+++ b/spring-cloud-deployer-admin-core/src/main/java/org/springframework/cloud/deployer/admin/core/dsl/Tokens.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-core/src/main/java/org/springframework/cloud/deployer/admin/core/dsl/package-info.java
+++ b/spring-cloud-deployer-admin-core/src/main/java/org/springframework/cloud/deployer/admin/core/dsl/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-core/src/test/java/org/springframework/cloud/deployer/admin/core/dsl/StreamParserTests.java
+++ b/spring-cloud-deployer-admin-core/src/test/java/org/springframework/cloud/deployer/admin/core/dsl/StreamParserTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-registry/src/main/java/org/springframework/cloud/deployer/admin/registry/AppRegistration.java
+++ b/spring-cloud-deployer-admin-registry/src/main/java/org/springframework/cloud/deployer/admin/registry/AppRegistration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-registry/src/main/java/org/springframework/cloud/deployer/admin/registry/AppRegistry.java
+++ b/spring-cloud-deployer-admin-registry/src/main/java/org/springframework/cloud/deployer/admin/registry/AppRegistry.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-registry/src/main/java/org/springframework/cloud/deployer/admin/registry/EavRegistryRepository.java
+++ b/spring-cloud-deployer-admin-registry/src/main/java/org/springframework/cloud/deployer/admin/registry/EavRegistryRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-registry/src/main/java/org/springframework/cloud/deployer/admin/registry/RdbmsEavRegistryRepository.java
+++ b/spring-cloud-deployer-admin-registry/src/main/java/org/springframework/cloud/deployer/admin/registry/RdbmsEavRegistryRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-registry/src/main/java/org/springframework/cloud/deployer/admin/registry/RdbmsUriRegistry.java
+++ b/spring-cloud-deployer-admin-registry/src/main/java/org/springframework/cloud/deployer/admin/registry/RdbmsUriRegistry.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-registry/src/main/java/org/springframework/cloud/deployer/admin/registry/support/NoSuchAppRegistrationException.java
+++ b/spring-cloud-deployer-admin-registry/src/main/java/org/springframework/cloud/deployer/admin/registry/support/NoSuchAppRegistrationException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-rest-client/src/main/java/org/springframework/cloud/deployer/admin/rest/client/AppRegistryOperations.java
+++ b/spring-cloud-deployer-admin-rest-client/src/main/java/org/springframework/cloud/deployer/admin/rest/client/AppRegistryOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-rest-client/src/main/java/org/springframework/cloud/deployer/admin/rest/client/AppRegistryTemplate.java
+++ b/spring-cloud-deployer-admin-rest-client/src/main/java/org/springframework/cloud/deployer/admin/rest/client/AppRegistryTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-rest-client/src/main/java/org/springframework/cloud/deployer/admin/rest/client/ApplicationOperations.java
+++ b/spring-cloud-deployer-admin-rest-client/src/main/java/org/springframework/cloud/deployer/admin/rest/client/ApplicationOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-rest-client/src/main/java/org/springframework/cloud/deployer/admin/rest/client/ApplicationTemplate.java
+++ b/spring-cloud-deployer-admin-rest-client/src/main/java/org/springframework/cloud/deployer/admin/rest/client/ApplicationTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-rest-client/src/main/java/org/springframework/cloud/deployer/admin/rest/client/CompletionOperations.java
+++ b/spring-cloud-deployer-admin-rest-client/src/main/java/org/springframework/cloud/deployer/admin/rest/client/CompletionOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-rest-client/src/main/java/org/springframework/cloud/deployer/admin/rest/client/CompletionTemplate.java
+++ b/spring-cloud-deployer-admin-rest-client/src/main/java/org/springframework/cloud/deployer/admin/rest/client/CompletionTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-rest-client/src/main/java/org/springframework/cloud/deployer/admin/rest/client/DataFlowClientException.java
+++ b/spring-cloud-deployer-admin-rest-client/src/main/java/org/springframework/cloud/deployer/admin/rest/client/DataFlowClientException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-rest-client/src/main/java/org/springframework/cloud/deployer/admin/rest/client/DataFlowOperations.java
+++ b/spring-cloud-deployer-admin-rest-client/src/main/java/org/springframework/cloud/deployer/admin/rest/client/DataFlowOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-rest-client/src/main/java/org/springframework/cloud/deployer/admin/rest/client/DataFlowServerException.java
+++ b/spring-cloud-deployer-admin-rest-client/src/main/java/org/springframework/cloud/deployer/admin/rest/client/DataFlowServerException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-rest-client/src/main/java/org/springframework/cloud/deployer/admin/rest/client/DataFlowTemplate.java
+++ b/spring-cloud-deployer-admin-rest-client/src/main/java/org/springframework/cloud/deployer/admin/rest/client/DataFlowTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-rest-client/src/main/java/org/springframework/cloud/deployer/admin/rest/client/RuntimeOperations.java
+++ b/spring-cloud-deployer-admin-rest-client/src/main/java/org/springframework/cloud/deployer/admin/rest/client/RuntimeOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-rest-client/src/main/java/org/springframework/cloud/deployer/admin/rest/client/RuntimeTemplate.java
+++ b/spring-cloud-deployer-admin-rest-client/src/main/java/org/springframework/cloud/deployer/admin/rest/client/RuntimeTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-rest-client/src/main/java/org/springframework/cloud/deployer/admin/rest/client/VndErrorResponseErrorHandler.java
+++ b/spring-cloud-deployer-admin-rest-client/src/main/java/org/springframework/cloud/deployer/admin/rest/client/VndErrorResponseErrorHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-rest-client/src/test/java/org/springframework/cloud/deployer/admin/rest/client/DataflowTemplateTests.java
+++ b/spring-cloud-deployer-admin-rest-client/src/test/java/org/springframework/cloud/deployer/admin/rest/client/DataflowTemplateTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-rest-resource/src/main/java/org/springframework/cloud/deployer/admin/rest/resource/AppInstanceStatusResource.java
+++ b/spring-cloud-deployer-admin-rest-resource/src/main/java/org/springframework/cloud/deployer/admin/rest/resource/AppInstanceStatusResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-rest-resource/src/main/java/org/springframework/cloud/deployer/admin/rest/resource/AppRegistrationResource.java
+++ b/spring-cloud-deployer-admin-rest-resource/src/main/java/org/springframework/cloud/deployer/admin/rest/resource/AppRegistrationResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-rest-resource/src/main/java/org/springframework/cloud/deployer/admin/rest/resource/AppStatusResource.java
+++ b/spring-cloud-deployer-admin-rest-resource/src/main/java/org/springframework/cloud/deployer/admin/rest/resource/AppStatusResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-rest-resource/src/main/java/org/springframework/cloud/deployer/admin/rest/resource/ApplicationDefinitionResource.java
+++ b/spring-cloud-deployer-admin-rest-resource/src/main/java/org/springframework/cloud/deployer/admin/rest/resource/ApplicationDefinitionResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-rest-resource/src/main/java/org/springframework/cloud/deployer/admin/rest/resource/ApplicationDeploymentResource.java
+++ b/spring-cloud-deployer-admin-rest-resource/src/main/java/org/springframework/cloud/deployer/admin/rest/resource/ApplicationDeploymentResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-rest-resource/src/main/java/org/springframework/cloud/deployer/admin/rest/resource/CompletionProposalsResource.java
+++ b/spring-cloud-deployer-admin-rest-resource/src/main/java/org/springframework/cloud/deployer/admin/rest/resource/CompletionProposalsResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-rest-resource/src/main/java/org/springframework/cloud/deployer/admin/rest/resource/DetailedAppRegistrationResource.java
+++ b/spring-cloud-deployer-admin-rest-resource/src/main/java/org/springframework/cloud/deployer/admin/rest/resource/DetailedAppRegistrationResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-rest-resource/src/main/java/org/springframework/cloud/deployer/admin/rest/resource/FeaturesInfoResource.java
+++ b/spring-cloud-deployer-admin-rest-resource/src/main/java/org/springframework/cloud/deployer/admin/rest/resource/FeaturesInfoResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-rest-resource/src/main/java/org/springframework/cloud/deployer/admin/rest/resource/security/SecurityInfoResource.java
+++ b/spring-cloud-deployer-admin-rest-resource/src/main/java/org/springframework/cloud/deployer/admin/rest/resource/security/SecurityInfoResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-rest-resource/src/main/java/org/springframework/cloud/deployer/admin/rest/util/DeploymentPropertiesUtils.java
+++ b/spring-cloud-deployer-admin-rest-resource/src/main/java/org/springframework/cloud/deployer/admin/rest/util/DeploymentPropertiesUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-rest-resource/src/test/java/org/springframework/cloud/deployer/admin/rest/job/support/DeploymentPropertiesUtilsTests.java
+++ b/spring-cloud-deployer-admin-rest-resource/src/test/java/org/springframework/cloud/deployer/admin/rest/job/support/DeploymentPropertiesUtilsTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/EnableDataFlowServer.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/EnableDataFlowServer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/config/DataFlowControllerAutoConfiguration.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/config/DataFlowControllerAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/config/DataFlowServerAutoConfiguration.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/config/DataFlowServerAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/config/DataFlowServerConfiguration.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/config/DataFlowServerConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/config/DefaultEnvironmentPostProcessor.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/config/DefaultEnvironmentPostProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/config/EnableDataFlowServerConfiguration.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/config/EnableDataFlowServerConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/config/apps/CommonApplicationProperties.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/config/apps/CommonApplicationProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/config/features/ApplicationConfiguration.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/config/features/ApplicationConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/config/features/FeaturesConfiguration.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/config/features/FeaturesConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/config/features/FeaturesProperties.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/config/features/FeaturesProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/config/security/BasicAuthSecurityConfiguration.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/config/security/BasicAuthSecurityConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/config/security/FileAuthenticationConfiguration.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/config/security/FileAuthenticationConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/config/security/LdapAuthenticationConfiguration.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/config/security/LdapAuthenticationConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/config/security/OAuthSecurityConfiguration.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/config/security/OAuthSecurityConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/config/security/support/LdapSecurityProperties.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/config/security/support/LdapSecurityProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/config/security/support/LdapSecurityPropertiesValid.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/config/security/support/LdapSecurityPropertiesValid.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/config/security/support/LdapSecurityPropertiesValidator.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/config/security/support/LdapSecurityPropertiesValidator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/config/security/support/OnOAuth2Disabled.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/config/security/support/OnOAuth2Disabled.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/config/security/support/OnSecurityEnabledAndOAuth2Disabled.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/config/security/support/OnSecurityEnabledAndOAuth2Disabled.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/config/security/support/OnSecurityEnabledAndOAuth2Enabled.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/config/security/support/OnSecurityEnabledAndOAuth2Enabled.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/controller/AppAlreadyRegisteredException.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/controller/AppAlreadyRegisteredException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/controller/AppRegistryController.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/controller/AppRegistryController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/controller/ApplicationAlreadyDeployedException.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/controller/ApplicationAlreadyDeployedException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/controller/ApplicationAlreadyDeployingException.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/controller/ApplicationAlreadyDeployingException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/controller/ApplicationDefinitionController.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/controller/ApplicationDefinitionController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/controller/ApplicationDeploymentController.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/controller/ApplicationDeploymentController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/controller/CompletionController.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/controller/CompletionController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/controller/RestControllerAdvice.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/controller/RestControllerAdvice.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/controller/RootController.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/controller/RootController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/controller/RuntimeAppsController.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/controller/RuntimeAppsController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/controller/UiController.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/controller/UiController.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/controller/WhitelistProperties.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/controller/WhitelistProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/controller/security/LoginController.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/controller/security/LoginController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/controller/security/SecurityController.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/controller/security/SecurityController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/controller/security/support/AuthenticationRequest.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/controller/security/support/AuthenticationRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/controller/support/InvalidStreamDefinitionException.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/controller/support/InvalidStreamDefinitionException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/repository/AbstractRdbmsKeyValueRepository.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/repository/AbstractRdbmsKeyValueRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/repository/ApplicationDefinitionRepository.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/repository/ApplicationDefinitionRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/repository/DeploymentIdRepository.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/repository/DeploymentIdRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/repository/DuplicateTaskException.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/repository/DuplicateTaskException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/repository/NoSuchApplicationDefinitionException.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/repository/NoSuchApplicationDefinitionException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/repository/NoSuchTaskDefinitionException.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/repository/NoSuchTaskDefinitionException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/repository/NoSuchTaskExecutionException.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/repository/NoSuchTaskExecutionException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/repository/RdbmsApplicationDefinitionRepository.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/repository/RdbmsApplicationDefinitionRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/repository/RdbmsDeploymentIdRepository.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/repository/RdbmsDeploymentIdRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/repository/support/AbstractSqlPagingQueryProvider.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/repository/support/AbstractSqlPagingQueryProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/repository/support/DatabaseType.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/repository/support/DatabaseType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/repository/support/DataflowRdbmsInitializer.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/repository/support/DataflowRdbmsInitializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/repository/support/Db2PagingQueryProvider.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/repository/support/Db2PagingQueryProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/repository/support/H2PagingQueryProvider.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/repository/support/H2PagingQueryProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/repository/support/HsqlPagingQueryProvider.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/repository/support/HsqlPagingQueryProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/repository/support/JdbcParameterUtils.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/repository/support/JdbcParameterUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/repository/support/MySqlPagingQueryProvider.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/repository/support/MySqlPagingQueryProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/repository/support/OraclePagingQueryProvider.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/repository/support/OraclePagingQueryProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/repository/support/Order.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/repository/support/Order.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/repository/support/PagingQueryProvider.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/repository/support/PagingQueryProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/repository/support/PostgresPagingQueryProvider.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/repository/support/PostgresPagingQueryProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/repository/support/SearchPageable.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/repository/support/SearchPageable.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/repository/support/SqlPagingQueryProviderFactoryBean.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/repository/support/SqlPagingQueryProviderFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/repository/support/SqlPagingQueryUtils.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/repository/support/SqlPagingQueryUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/repository/support/SqlServerPagingQueryProvider.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/repository/support/SqlServerPagingQueryProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/service/impl/ManualOAuthAuthenticationProvider.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/service/impl/ManualOAuthAuthenticationProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/support/CannotDetermineApplicationTypeException.java
+++ b/spring-cloud-deployer-admin-server-core/src/main/java/org/springframework/cloud/deployer/admin/server/support/CannotDetermineApplicationTypeException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/test/java/org/springframework/cloud/deployer/admin/server/config/DefaultEnvironmentPostProcessorTests.java
+++ b/spring-cloud-deployer-admin-server-core/src/test/java/org/springframework/cloud/deployer/admin/server/config/DefaultEnvironmentPostProcessorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/test/java/org/springframework/cloud/deployer/admin/server/config/security/FileAuthenticationConfigurationTests.java
+++ b/spring-cloud-deployer-admin-server-core/src/test/java/org/springframework/cloud/deployer/admin/server/config/security/FileAuthenticationConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/test/java/org/springframework/cloud/deployer/admin/server/config/security/OnSecurityEnabledAndOAuth2DisabledTests.java
+++ b/spring-cloud-deployer-admin-server-core/src/test/java/org/springframework/cloud/deployer/admin/server/config/security/OnSecurityEnabledAndOAuth2DisabledTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/test/java/org/springframework/cloud/deployer/admin/server/config/security/OnSecurityEnabledAndOAuth2EnabledTests.java
+++ b/spring-cloud-deployer-admin-server-core/src/test/java/org/springframework/cloud/deployer/admin/server/config/security/OnSecurityEnabledAndOAuth2EnabledTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/test/java/org/springframework/cloud/deployer/admin/server/configuration/TestDependencies.java
+++ b/spring-cloud-deployer-admin-server-core/src/test/java/org/springframework/cloud/deployer/admin/server/configuration/TestDependencies.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/test/java/org/springframework/cloud/deployer/admin/server/controller/AppRegistryControllerTests.java
+++ b/spring-cloud-deployer-admin-server-core/src/test/java/org/springframework/cloud/deployer/admin/server/controller/AppRegistryControllerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/test/java/org/springframework/cloud/deployer/admin/server/registry/DataFlowUriRegistryPopulator.java
+++ b/spring-cloud-deployer-admin-server-core/src/test/java/org/springframework/cloud/deployer/admin/server/registry/DataFlowUriRegistryPopulator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/test/java/org/springframework/cloud/deployer/admin/server/registry/RdbmsUriRegistryTests.java
+++ b/spring-cloud-deployer-admin-server-core/src/test/java/org/springframework/cloud/deployer/admin/server/registry/RdbmsUriRegistryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-core/src/test/java/org/springframework/cloud/deployer/admin/server/repository/support/SearchPageableTests.java
+++ b/spring-cloud-deployer-admin-server-core/src/test/java/org/springframework/cloud/deployer/admin/server/repository/support/SearchPageableTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-server-local/src/main/java/org/springframework/cloud/deployer/admin/server/local/LocalDataFlowServer.java
+++ b/spring-cloud-deployer-admin-server-local/src/main/java/org/springframework/cloud/deployer/admin/server/local/LocalDataFlowServer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/EnableDataFlowShell.java
+++ b/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/EnableDataFlowShell.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/ShellApplication.java
+++ b/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/ShellApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/ShellCommandLineParser.java
+++ b/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/ShellCommandLineParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/ShellCommandLineRunner.java
+++ b/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/ShellCommandLineRunner.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/ShellProperties.java
+++ b/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/ShellProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/Target.java
+++ b/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/Target.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/TargetHolder.java
+++ b/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/TargetHolder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/autoconfigure/BaseShellAutoConfiguration.java
+++ b/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/autoconfigure/BaseShellAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/command/AppRegistryCommands.java
+++ b/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/command/AppRegistryCommands.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/command/ApplicationCommands.java
+++ b/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/command/ApplicationCommands.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/command/Assertions.java
+++ b/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/command/Assertions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/command/ConfigCommands.java
+++ b/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/command/ConfigCommands.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/command/ConsoleUserInput.java
+++ b/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/command/ConsoleUserInput.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/command/DataFlowTables.java
+++ b/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/command/DataFlowTables.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/command/HttpCommands.java
+++ b/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/command/HttpCommands.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/command/RuntimeCommands.java
+++ b/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/command/RuntimeCommands.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/command/UserInput.java
+++ b/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/command/UserInput.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/command/support/HttpClientUtils.java
+++ b/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/command/support/HttpClientUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/config/DataFlowBannerProvider.java
+++ b/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/config/DataFlowBannerProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/config/DataFlowPromptProvider.java
+++ b/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/config/DataFlowPromptProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/config/DataFlowShell.java
+++ b/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/config/DataFlowShell.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/config/ShellCommandLineConfiguration.java
+++ b/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/config/ShellCommandLineConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/converter/CompletionConverter.java
+++ b/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/converter/CompletionConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/converter/MediaTypeConverter.java
+++ b/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/converter/MediaTypeConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/converter/NumberFormatConverter.java
+++ b/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/converter/NumberFormatConverter.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/converter/QualifiedApplicationNameConverter.java
+++ b/spring-cloud-deployer-admin-shell-core/src/main/java/org/springframework/cloud/deployer/admin/shell/converter/QualifiedApplicationNameConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-shell-core/src/test/java/org/springframework/cloud/deployer/admin/shell/AbstractShellIntegrationTest.java
+++ b/spring-cloud-deployer-admin-shell-core/src/test/java/org/springframework/cloud/deployer/admin/shell/AbstractShellIntegrationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-shell-core/src/test/java/org/springframework/cloud/deployer/admin/shell/command/AppRegistryCommandsTests.java
+++ b/spring-cloud-deployer-admin-shell-core/src/test/java/org/springframework/cloud/deployer/admin/shell/command/AppRegistryCommandsTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-shell-core/src/test/java/org/springframework/cloud/deployer/admin/shell/command/AssertionsTests.java
+++ b/spring-cloud-deployer-admin-shell-core/src/test/java/org/springframework/cloud/deployer/admin/shell/command/AssertionsTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-shell-core/src/test/java/org/springframework/cloud/deployer/admin/shell/command/ConfigCommandTests.java
+++ b/spring-cloud-deployer-admin-shell-core/src/test/java/org/springframework/cloud/deployer/admin/shell/command/ConfigCommandTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-shell-core/src/test/java/org/springframework/cloud/deployer/admin/shell/command/RuntimeCommandsTests.java
+++ b/spring-cloud-deployer-admin-shell-core/src/test/java/org/springframework/cloud/deployer/admin/shell/command/RuntimeCommandsTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-admin-shell/src/main/java/org/springframework/cloud/deployer/admin/shell/app/ShellApplication.java
+++ b/spring-cloud-deployer-admin-shell/src/main/java/org/springframework/cloud/deployer/admin/shell/app/ShellApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-deployer-admin-server-local/src/test/java/org/springframework/cloud/deployer/admin/server/local/LocalConfigurationTests.java
+++ b/spring-cloud-starter-deployer-admin-server-local/src/test/java/org/springframework/cloud/deployer/admin/server/local/LocalConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-deployer-admin-server-local/src/test/java/org/springframework/cloud/deployer/admin/server/local/LocalDataflowResource.java
+++ b/spring-cloud-starter-deployer-admin-server-local/src/test/java/org/springframework/cloud/deployer/admin/server/local/LocalDataflowResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-deployer-admin-server-local/src/test/java/org/springframework/cloud/deployer/admin/server/local/TestUtils.java
+++ b/spring-cloud-starter-deployer-admin-server-local/src/test/java/org/springframework/cloud/deployer/admin/server/local/TestUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-deployer-admin-server-local/src/test/java/org/springframework/cloud/deployer/admin/server/local/dataflowapp/LocalTestDataFlowServer.java
+++ b/spring-cloud-starter-deployer-admin-server-local/src/test/java/org/springframework/cloud/deployer/admin/server/local/dataflowapp/LocalTestDataFlowServer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-deployer-admin-server-local/src/test/java/org/springframework/cloud/deployer/admin/server/local/nodataflowapp/LocalTestNoDataFlowServer.java
+++ b/spring-cloud-starter-deployer-admin-server-local/src/test/java/org/springframework/cloud/deployer/admin/server/local/nodataflowapp/LocalTestNoDataFlowServer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-deployer-admin-server-local/src/test/java/org/springframework/cloud/deployer/admin/server/local/security/ApacheDSContainerWithSecurity.java
+++ b/spring-cloud-starter-deployer-admin-server-local/src/test/java/org/springframework/cloud/deployer/admin/server/local/security/ApacheDSContainerWithSecurity.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-deployer-admin-server-local/src/test/java/org/springframework/cloud/deployer/admin/server/local/security/LdapServerResource.java
+++ b/spring-cloud-starter-deployer-admin-server-local/src/test/java/org/springframework/cloud/deployer/admin/server/local/security/LdapServerResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-deployer-admin-server-local/src/test/java/org/springframework/cloud/deployer/admin/server/local/security/LocalServerSecurityWithLdapSearchAndBindSslTests.java
+++ b/spring-cloud-starter-deployer-admin-server-local/src/test/java/org/springframework/cloud/deployer/admin/server/local/security/LocalServerSecurityWithLdapSearchAndBindSslTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-deployer-admin-server-local/src/test/java/org/springframework/cloud/deployer/admin/server/local/security/LocalServerSecurityWithLdapSearchAndBindTests.java
+++ b/spring-cloud-starter-deployer-admin-server-local/src/test/java/org/springframework/cloud/deployer/admin/server/local/security/LocalServerSecurityWithLdapSearchAndBindTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-deployer-admin-server-local/src/test/java/org/springframework/cloud/deployer/admin/server/local/security/LocalServerSecurityWithLdapSimpleBindAndDefaultManagementTests.java
+++ b/spring-cloud-starter-deployer-admin-server-local/src/test/java/org/springframework/cloud/deployer/admin/server/local/security/LocalServerSecurityWithLdapSimpleBindAndDefaultManagementTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-deployer-admin-server-local/src/test/java/org/springframework/cloud/deployer/admin/server/local/security/LocalServerSecurityWithLdapSimpleBindTests.java
+++ b/spring-cloud-starter-deployer-admin-server-local/src/test/java/org/springframework/cloud/deployer/admin/server/local/security/LocalServerSecurityWithLdapSimpleBindTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-deployer-admin-server-local/src/test/java/org/springframework/cloud/deployer/admin/server/local/security/SecurityTestUtils.java
+++ b/spring-cloud-starter-deployer-admin-server-local/src/test/java/org/springframework/cloud/deployer/admin/server/local/security/SecurityTestUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 195 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).